### PR TITLE
make addon aware of active prop so storybook renders in its own panel

### DIFF
--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -6,6 +6,7 @@ import {Theme} from "./types/Theme";
 export interface ThemeProps {
     channel: any;
     api: any;
+    active: Boolean;
 }
 
 interface ThemeState {
@@ -22,13 +23,15 @@ interface ThemeHandler {
 
 type BaseComponentProps = ThemeProps & ThemeState & ThemeHandler;
 
-const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, theme}) => (
+const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, theme, active}) => (
+    active ? (
     <div style={RowStyle}>
         {themes.map((th, i) => {
             const buttonStyle = th === theme ? SelectedButtonStyle : ButtonStyle;
             return <div style={buttonStyle} key={i} onClick={() => onSelectTheme(th)}>{th.name}</div>;
         }).toArray()}
-    </div>
+    </div> )
+    : (<div />)
 );
 
 export const Themes = compose<BaseComponentProps, ThemeProps>(

--- a/src/__tests__/Themes.spec.tsx
+++ b/src/__tests__/Themes.spec.tsx
@@ -11,7 +11,7 @@ describe("Themes spec", () => {
             removeListener: stub(),
         };
 
-        const component = mount(<Themes api={null} channel={channel} />);
+        const component = mount(<Themes api={null} active={true} channel={channel} />);
         expect(component.render()).toMatchSnapshot();
         expect(channel.on.calledOnce).toBeTruthy();
         expect(channel.emit.notCalled).toBeTruthy();

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -6,6 +6,6 @@ addons.register("storybook/themes", (api) => {
     // Also need to set a unique name to the panel.
     addons.addPanel("storybook/themes/panel", {
         title: "Themes",
-        render: () => (<Themes channel={addons.getChannel()} api={api} />),
+        render: ({ active }) => (<Themes channel={addons.getChannel()} api={api} active={active} />),
     });
 });


### PR DESCRIPTION
For this addon to render only in it's own "Themes"-panel in Storybook, it needs to be aware of the 'active'-prop as discussed in [this issue](https://github.com/storybooks/storybook/issues/4200#issuecomment-425896039). Right now, the addon will render in all registered panels, e.g. also within Knobs-Panel, View Port-Panel, etc.

Greets
-act