### PR TITLE
Add support for an optional CustomThemeProvider

### DIFF
--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -2,11 +2,12 @@ import addons from "@storybook/addons";
 import {List} from "immutable";
 import * as React from "react";
 import {branch, compose, lifecycle, renderNothing, withState} from "recompose";
-import {ThemeProvider} from "styled-components";
+import {ThemeProvider as StyledThemeProvider} from "styled-components";
 import {Theme} from "./types/Theme";
 
 export interface ThemesProviderProps {
     themes: List<Theme>;
+    CustomThemeProvider?: StyledThemeProvider;
 }
 
 interface ThemesProviderState {
@@ -19,11 +20,14 @@ interface ThemesProviderHandler {
 
 type BaseComponentProps = ThemesProviderProps & ThemesProviderState & ThemesProviderHandler;
 
-const BaseComponent: React.SFC<BaseComponentProps> = ({theme, children}) => (
-    <ThemeProvider theme={theme}>
-        {children}
-    </ThemeProvider>
-);
+const BaseComponent: React.SFC<BaseComponentProps> = ({theme, CustomThemeProvider, children}) => {
+    const ThemeProvider = CustomThemeProvider ? CustomThemeProvider : StyledThemeProvider;
+    return (
+        <ThemeProvider theme={theme}>
+            {children}
+        </ThemeProvider>
+    );
+};
 
 export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
     withState("theme", "setTheme", null),

--- a/src/withThemesProvider.tsx
+++ b/src/withThemesProvider.tsx
@@ -4,6 +4,6 @@ import {makeDecorator} from "@storybook/addons";
 import {ThemesProvider} from "./ThemesProvider";
 import {Theme} from "./types/Theme";
 
-export const withThemesProvider = (themes: Theme[]) => (story): JSX.Element => {
-    return <ThemesProvider themes={List(themes)}>{story()}</ThemesProvider>;
+export const withThemesProvider = (themes: Theme[], CustomThemeProvider) => (story): JSX.Element => {
+    return <ThemesProvider themes={List(themes)} CustomThemeProvider={CustomThemeProvider}>{story()}</ThemesProvider>;
 };


### PR DESCRIPTION
Close #11

Usage:

```config.js
import { ThemeProvider as MaterialThemeProvide } from '@material-ui/styles';
import { withThemesProvider } from 'storybook-addon-styled-component-theme';
import { ThemeProvider as StyledThemeProvider } from 'styled-components';

const CustomThemeProvider = ({ theme, children }) => (
  <StyledThemeProvider theme={theme}>
    <MaterialThemeProvide theme={theme}>{children}</MaterialThemeProvide>
  </StyledThemeProvider>
);

addDecorator(withThemesProvider(themes, CustomThemeProvider));

```

Note: I never done any TypeScript before and never used recompose so I might I done things the wrong way.