### PR TITLE
Fix typo in README configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ import { withThemesProvider } from "storybook-addon-styled-component-theme";
 import { ThemeProvider } from "styled-components";
 
 const themes = [theme1, theme2];
-addDecorator(withThemesProvider(themes), ThemeProvider);
+addDecorator(withThemesProvider(themes, ThemeProvider));
 ```
 
 #### Add to .storybook/main.js


### PR DESCRIPTION
Fix is based on https://github.com/echoulen/storybook-addon-styled-component-theme/blob/master/src/withThemesProvider.tsx#L7.